### PR TITLE
Fix: Add fallback for multiple frameworks

### DIFF
--- a/commands/secret.js
+++ b/commands/secret.js
@@ -31,6 +31,7 @@ export async function action(options) {
     introCopy:
       "Secret generated. Copy it to your .env/.env.local file (depending on your framework):",
     value: `\n${line}`,
+    multipleFrameworks: `Secret generated. Copy it to your .env/.env.local file (depending on your framework):${value}`,
   }
 
   if (options.copy) {
@@ -47,7 +48,22 @@ export async function action(options) {
   }
 
   try {
-    await requireFramework(options.path)
+    const framework = await requireFramework(options.path)
+    if (framework === "multiple-frameworks-detected") {
+      try {
+        clipboard.writeSync(line)
+        console.log(message.introClipboard)
+      } catch (error) {
+        console.log(
+          "An error occurred while copying the secret to your clipboard."
+        )
+        console.log(message.multipleFrameworks)
+        console.log(message.value)
+      } finally {
+        process.exit(0)
+      }
+    }
+
     await updateEnvFile({ [key]: value }, options.path)
   } catch (error) {
     console.error(y.red(error))

--- a/lib/detect.js
+++ b/lib/detect.js
@@ -8,7 +8,7 @@ import * as y from "yoctocolors"
  * When this function runs in a framework directory we support,
  * it will return the framework's name
  * @param {string} path
- * @returns {Promise<import("./meta").SupportedFramework | "unknown">}
+ * @returns {Promise<import("./meta").SupportedFramework | "unknown" | "multiple-frameworks-detected">}
  */
 export async function detectFramework(path = "") {
   const dir = process.cwd()
@@ -27,10 +27,8 @@ export async function detectFramework(path = "") {
     if (foundFrameworks.length === 1) return foundFrameworks[0]
 
     if (foundFrameworks.length > 1) {
-      console.error(
-        `Multiple supported frameworks detected: ${foundFrameworks.join(", ")}`
-      )
-      return "unknown"
+      console.log("Multiple supported frameworks detected.")
+      return "multiple-frameworks-detected"
     }
     return "unknown"
   } catch (error) {

--- a/lib/detect.js
+++ b/lib/detect.js
@@ -32,8 +32,9 @@ export async function detectFramework(path = "") {
     }
     return "unknown"
   } catch (error) {
+    console.error("An error occurred while detecting the framework.")
     console.error(error)
-    return "unknown"
+    process.exit(0)
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->

## 🧢 Checklist

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

## 🎫 Affected issues
Fixes #20

Hi team,
Came across this issue yesterday and had a few minutes today.

1)
In short if multiple frameworks are detected the below will be the terminal output. 
(Confirmed copy to clipboard as working)

```terminal 
auth secret
Multiple supported frameworks detected.
Secret generated. It has been copied to your clipboard, paste it to your .env/.env.local file to continue.
```
if copy to clipboard fails
the auth secret will still be added to the terminal for the Developer to add to their own file / files.

2)
I also added a little bit of error handling to detect.js

```javascript
 console.error("An error occurred while detecting the framework.")
    console.error(error)
    process.exit(0)
```
The thinking here was that since the origin return is "unknown"  this would cause 2 error messages as highlighted below
error one in line 38

[https://github.com/nextauthjs/cli/blob/main/lib/detect.js#L38](https://github.com/nextauthjs/cli/blob/main/lib/detect.js#L38)

error 2 in line 46
```terminal
No framework detected. Currently supported frameworks are: next, sveltekit, expres
```
[https://github.com/nextauthjs/cli/blob/main/lib/detect.js#L46](https://github.com/nextauthjs/cli/blob/main/lib/detect.js#L46)

Which is a potential cause of confusion (as highlighted in Issue 20)

I opted to just end the process after the error.

Feedback welcome.
Have a great day.

<!-- 
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
